### PR TITLE
feat: feedback del 6 de junio

### DIFF
--- a/src/app/[locale]/(pages)/blog/page.jsx
+++ b/src/app/[locale]/(pages)/blog/page.jsx
@@ -27,22 +27,14 @@ export default function Index() {
     <>
       <Head>
         <title>Blog | Travel Design</title>
-        <meta
-          name="description"
-          content="Descubre Kenia y la reserva Masái Mara con Travel Design"
-        />
+        <meta name="description" content="Blog de Travel Design" />
       </Head>
 
       <main>
         <section className="hero-section position-relative">
-          <div
-            className="position-relative"
-            style={{ height: "100vh", width: "100%" }}
-          >
-            <img src="/assets/img/blog-header.jpg" alt="Kenia - Masái Mara" />
-            <div className="overlay d-flex align-items-center justify-content-center">
-              <h1 className="text-center text-white">Blog</h1>
-            </div>
+          <img src="/assets/img/blog-header.jpg" alt="imagen-blog" />
+          <div className="overlay d-flex align-items-center justify-content-center">
+            <h1 className="text-center text-white">Blog</h1>
           </div>
         </section>
 

--- a/src/app/[locale]/(pages)/nosotros/page.jsx
+++ b/src/app/[locale]/(pages)/nosotros/page.jsx
@@ -25,7 +25,7 @@ export default function NosotrosPage() {
     <>
       <main>
         <section className="hero-section">
-          <img src="/assets/img/nosotros-header.png" alt="kenia" />
+          <img src="/assets/img/nosotros-header.png" alt="imagen-nosotros" />
           <div className="overlay">
             <h1>{t("title")}</h1>
           </div>

--- a/src/app/[locale]/components/SwiperPagination.jsx
+++ b/src/app/[locale]/components/SwiperPagination.jsx
@@ -14,7 +14,9 @@ export default function SwiperPagination({ data }) {
       <div className="container">
         <div className="row">
           <div className="col">
-            <h2 className="title-section mb-5">Top 10 Destinos</h2>
+            <h2 className="title-section mb-5">
+              {t("top-destinations-section.title")}
+            </h2>
             <div className={`swiper`}>
               <div className="swiper-cards-slider">
                 <Swiper

--- a/src/app/[locale]/page.jsx
+++ b/src/app/[locale]/page.jsx
@@ -53,14 +53,7 @@ export default function Home() {
           </div>
         </div>
       </section>
-      <SwiperPagination
-        data={destinations}
-        // swiper="swiper-cards-slider"
-        // swiperPagination="swiper-pagination-top-10"
-        // title={t("top-destinations-section.title")}
-        // type="destinations"
-        // pathByItem="/destinations/"
-      />
+      <SwiperPagination data={destinations} />
       <ExperienceSlider />
     </div>
   );


### PR DESCRIPTION
## Implementaciones

- [x] En las paginas internas, como la del blog, el header lo sienten demasiado alto, es decir, cubre casi toda la pantalla, algo como el header de la seccion "nosotros" sería lo ideal.
- [x]  En las experiencias falta la paginación (deben ir máximo 6 y despues la paginación)
- [x]  En el home el slide de hasta abajo perdio las flechas de izquierda y derecha. (por cierto este carousel es manual o se alimenta de headers de las secciones?)
- [x]  Cuando se esta esta en la versión "inglés" en el home , el carousel de "top 10" muestra el texto en español